### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/latinize.js
+++ b/latinize.js
@@ -17,7 +17,7 @@
         return latinize.characters[x] || x;
       });
     } else {
-      if (str == constructor.prototype)
+      if (str === constructor.prototype)
         str = {}
       return str;
     }

--- a/latinize.js
+++ b/latinize.js
@@ -17,6 +17,8 @@
         return latinize.characters[x] || x;
       });
     } else {
+      if (str == constructor.prototype)
+        str = {}
       return str;
     }
   }

--- a/poc.js
+++ b/poc.js
@@ -1,0 +1,5 @@
+var latinize = require('./latinize');
+const obj = {}
+console.log('Before: ' + {}.polluted)
+latinize(obj['__proto__'], {}).polluted = 'Polluted!'
+console.log('After: ' + {}.polluted)

--- a/poc.js
+++ b/poc.js
@@ -1,5 +1,0 @@
-var latinize = require('./latinize');
-const obj = {}
-console.log('Before: ' + {}.polluted)
-latinize(obj['__proto__'], {}).polluted = 'Polluted!'
-console.log('After: ' + {}.polluted)


### PR DESCRIPTION
### :bar_chart: Metadata *

`latinize` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-latinize

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
var latinize = require('latinize');
const obj = {}
console.log('Before: ' + {}.polluted)
latinize(obj['__proto__'], {}).polluted = 'Polluted!'
console.log('After: ' + {}.polluted)
```
2. Execute the following commands in terminal:
```bash
npm i latinize # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before: undefined
After: Polluted!
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/104120618-281db980-535e-11eb-9eab-c39d22b04015.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
